### PR TITLE
[BOT]/Maryia/ WALL-3327/ On clicking `trader's hub icon on top, user is navigated to blank page

### DIFF
--- a/src/components/Header/WalletAccountSwitcher/account-wallet-dropdown.jsx
+++ b/src/components/Header/WalletAccountSwitcher/account-wallet-dropdown.jsx
@@ -90,7 +90,7 @@ const AccountWalletDropdown = React.forwardRef(({ setIsAccDropdownOpen }, dropdo
                     <div className='account__switcher-total-wallet'>
                         <span>{translate('Looking for CFDs? Go to Trader\'s hub')}</span>
 
-                        <a href={'/wallets'} className={'account__switcher-total--link'}>
+                        <a href={config.wallets.url} className={'account__switcher-total--link'}>
                             <img
                                 className={'header__expand'}
                                 src='/public/images/ic-chevron-down-bold.svg'

--- a/src/components/Header/WalletAccountSwitcher/account-wallet-dropdown.jsx
+++ b/src/components/Header/WalletAccountSwitcher/account-wallet-dropdown.jsx
@@ -90,7 +90,7 @@ const AccountWalletDropdown = React.forwardRef(({ setIsAccDropdownOpen }, dropdo
                     <div className='account__switcher-total-wallet'>
                         <span>{translate('Looking for CFDs? Go to Trader\'s hub')}</span>
 
-                        <a href={config.tradershub.url} className={'account__switcher-total--link'}>
+                        <a href={'/wallets'} className={'account__switcher-total--link'}>
                             <img
                                 className={'header__expand'}
                                 src='/public/images/ic-chevron-down-bold.svg'

--- a/src/components/Header/menu-links.jsx
+++ b/src/components/Header/menu-links.jsx
@@ -9,7 +9,10 @@ const MenuLinks = () => {
         <div className='header__menu-item header__menu-links client_logged_in'>
             {!has_wallet_account && config.reports.visible && (
                 <div>
-                    <a className='url-reports-positions header__menu-links-item' href={config.tradershub.url}>
+                    <a
+                        className='url-reports-positions header__menu-links-item'
+                        href={has_wallet_account ? '/wallets' : config.tradershub.url}
+                    >
                         <div className='header__icon-container'>
                             <img className='header__icon-text reports-icon' src='/public/images/traders_hub.png' />
                         </div>

--- a/src/components/Header/menu-links.jsx
+++ b/src/components/Header/menu-links.jsx
@@ -11,7 +11,7 @@ const MenuLinks = () => {
                 <div>
                     <a
                         className='url-reports-positions header__menu-links-item'
-                        href={has_wallet_account ? '/wallets' : config.tradershub.url}
+                        href={has_wallet_account ? config.wallets.url : config.tradershub.url}
                     >
                         <div className='header__icon-container'>
                             <img className='header__icon-text reports-icon' src='/public/images/traders_hub.png' />

--- a/src/config.js
+++ b/src/config.js
@@ -201,6 +201,9 @@ const getConfig = () => ({
         url: generateDerivLink('appstore/traders-hub'),
         label: translate('Trader\'s Hub'),
     },
+    wallets: {
+        url: generateDerivLink('wallets'),
+    },
     deposit: {
         visible: true,
         label: translate('Manage funds'),


### PR DESCRIPTION
## Changes:

1. On clicking the trader's hub icon on the top menu should redirect to [app url]`/wallets`
2. On clicking the trader's hub icon on the account switcher should redirect to [app url]`/wallets`

### Screenshots:

Please provide some screenshots of the change.
